### PR TITLE
contrib/taylan.kammer: Fix build errors on Guile.

### DIFF
--- a/contrib/taylan.kammer/64/execution.body.scm
+++ b/contrib/taylan.kammer/64/execution.body.scm
@@ -382,9 +382,7 @@
      (let* ((port (open-input-string string))
             (form (read port)))
        (if (eof-object? (read-char port))
-           (if env
-               (eval form env)
-               (eval form))
+           (eval form env)
            (error "(not at eof)"))))))
 
 

--- a/contrib/taylan.kammer/64/execution.sld
+++ b/contrib/taylan.kammer/64/execution.sld
@@ -12,5 +12,8 @@
    (srfi 64 source-info)
    (srfi 64 test-runner)
    (srfi 64 test-runner-simple))
+  (cond-expand
+   (guile
+    (import (only (guile) current-module))))
   (include-library-declarations "execution.exports.sld")
   (include "execution.body.scm"))

--- a/contrib/taylan.kammer/64/source-info.sld
+++ b/contrib/taylan.kammer/64/source-info.sld
@@ -1,6 +1,10 @@
 (define-library (srfi 64 source-info)
   (import
+   (rnrs syntax-case (6))
    (scheme base)
    (srfi 64 test-runner))
+  (cond-expand
+   (guile
+    (import (only (guile) assq-ref syntax-source))))
   (export source-info set-source-info!)
   (include "source-info.body.scm"))


### PR DESCRIPTION
This change fixes a few unbound variables errors as seen when integrating/building the Guile 3.0.9 main development branch.

* contrib/taylan.kammer/64/execution.body.scm (test-read-eval-string): Always provide the 2nd environment argument.
* contrib/taylan.kammer/64/execution.sld (srfi 64 execution) [guile]: Import 'current-module'.
* contrib/taylan.kammer/64/source-info.sld (srfi 64 source-info): Import (rnrs syntax-case (6)). [guile]: Import assq-ref, syntax-source.

With these changes I could verify that this 2nd implementation successfully passes the existing SRFI 64 test suite.